### PR TITLE
Trek team rename

### DIFF
--- a/2023/tour/cyclists.yaml
+++ b/2023/tour/cyclists.yaml
@@ -189,7 +189,7 @@
     - Daniel Oss
     - Peter Sagan
     - Anthony Turgis
-- teamName: Trek-Segafredo
+- teamName: Lidl-Trek
   cyclists:
     - Giulio Ciccone
     - Tony Gallopin


### PR DESCRIPTION
Trek segafrado heet vanaf 30 juni Lidl-Trek